### PR TITLE
Catch Failed Tasks During Deployment

### DIFF
--- a/pkg/deploy/mock_ecs.go
+++ b/pkg/deploy/mock_ecs.go
@@ -18,6 +18,7 @@ const (
 
 type MockECSClient struct {
 	DeploymentState ecstypes.DeploymentRolloutState
+	FailedTasks     int32
 	TestingT        *testing.T
 	WantError       bool
 }
@@ -86,6 +87,7 @@ func (c MockECSClient) DescribeServices(ctx context.Context, params *ecs.Describ
 			Id:           aws.String("some-deployment-id"),
 			RolloutState: c.DeploymentState,
 			Status:       aws.String("PRIMARY"),
+			FailedTasks:  c.FailedTasks,
 		},
 	}
 

--- a/pkg/deploy/service.go
+++ b/pkg/deploy/service.go
@@ -88,6 +88,11 @@ func CheckDeploymentStatus(ctx context.Context, c types.ECSClient, service strin
 		return true, err
 	}
 
+	if out.Services[0].Deployments[0].FailedTasks > 0 {
+		log.Printf("Deployment %d has failed tasks\n", out.Services[0].Deployments[0].FailedTasks)
+		return true, errors.New("deployment failed")
+	}
+
 	if out.Services[0].Deployments[0].RolloutState == "IN_PROGRESS" {
 		return false, nil
 	} else if out.Services[0].Deployments[0].RolloutState == "COMPLETED" {

--- a/pkg/deploy/service_test.go
+++ b/pkg/deploy/service_test.go
@@ -84,6 +84,22 @@ func TestCheckDeploymentStatus(t *testing.T) {
 			want:    true,
 			wantErr: true,
 		},
+		{
+			name: "test-failed-tasks",
+			args: args{
+				ctx: context.TODO(),
+				c: MockECSClient{
+					TestingT:        t,
+					DeploymentState: "IN_PROGRESS",
+					FailedTasks:     2,
+				},
+				service:      "test-service",
+				cluster:      "test-cluster",
+				deploymentID: "test-deployment-id",
+			},
+			want:    true,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When an ECS service has the deployment circuit breaker enabled, ECS will still mark the deployment complete even if the deployment failed and ECS rolled back.

The plugin will now look for failed tasks within a deployment. If failed tasks are found, the plugin will initiate a rollback